### PR TITLE
Do not replace underscores in URL segment(T157378)

### DIFF
--- a/paws/__init__.py
+++ b/paws/__init__.py
@@ -38,7 +38,7 @@ class NotebookLoader:
             sys.modules[fullname] = mod
             return mod
         
-        url_segment = '/'.join([s.replace('_', ' ') for s in parts]) + '.ipynb?format=raw'
+        url_segment = '/'.join(parts) + '.ipynb?format=raw'
         url = 'https://paws-public.wmflabs.org/paws-public/User:' + url_segment
         resp = requests.get(url)
         if resp.status_code == 404:


### PR DESCRIPTION
User/filenames containing underscores will not be found if it's replaced with a space.
https://phabricator.wikimedia.org/T157378

I have not been able to found the reason for underscores being replaced in the first place.